### PR TITLE
Add cross dependency. Fix linear dependency. Correct documentation spelling.

### DIFF
--- a/R/generateRow.R
+++ b/R/generateRow.R
@@ -1,27 +1,27 @@
-#' Generate a raw with statistical properties
+#' Generate a row with statistical properties
 #'
-#' @param dim Number of dimension of the generated vector
-#' @param subspaces List of subspaces that contain a dependency.
-#' @param margins List of margins that correspond to each subspace.
-#' @param dependency Type of dependency for the subspaces (We don't support 'mixed') currently 
-#' @param prop Probability of a point belonging to the hidden space of a subspace to become an outlier.
-#' @param proptype Type of the proportion of outliers. Value "proportional": depend on the size of the empty space. Value "absolute": same absolute proportion per subspace. 
+#' @param dim Number of dimensions of the generated vector
+#' @param subspaces List of subspaces that contain a dependency
+#' @param margins List of margins that correspond to each subspace
+#' @param dependency Type of dependency for the subspaces (We don't support 'mixed' currently)
+#' @param prop Probability of a point belonging to the hidden space of a subspace to become an outlier
+#' @param proptype Type of the proportion of outliers. Value "proportional": depends on the size of the empty space. Value "absolute": same absolute proportion per subspace. 
 #'
 #' @return A list with 2 elements where \code{data} contains the generated vector and \code{labels} the corresponding label.
 #
 #' @details
-#' The row is at first drawn from the uniform distribution between 0 and 1 over each dimension
+#' The row is at first drawn from the uniform distribution between 0 and 1 over each dimension.
 #' For each subspace in \code{subspaces}, if the point belongs to the hidden space of the specified dependency 
 #' (i.e. for the "Wall", the value for each dimension of the subspace if bigger than the 1-margin), 
-#' then it becomes an outlier with probability \code{prop}. If it is an outlier, it would stay in the hidden space 
-#' and we make sure it is not too close from the border by rescaling the value so that it is at least 10% of the hidden space away from it. 
-#' If it is not an outlier, we map uniformly the point to the dependencies (i.e. for "Wall", one of the axis or center (for a 3-D dimensions))
-#' The probability to be mapped to one of such element is determined by their volume
+#' it then becomes an outlier with probability \code{prop}. If it is an outlier, it would stay in the hidden space 
+#' and we make sure it is not too close to the border by rescaling the value so that it is at least 10% of the hidden space away from it. 
+#' If it is not an outlier, we map uniformly the point to the dependencies (i.e. for "Wall", one of the axis or center (for a 3-D dimensions)).
+#' The probability to be mapped to one of such element is determined by their volume.
 #' The bigger the area, the more likely the point will be mapped to the area. 
-#' In the case a point is already an outlier in a subspace, it cannot become and outlier in an overlapping subspace
-#' But it still has the same probability to become an outlier in another space. This appends occasionally (pigeonhole principle)
+#' In the case a point is already an outlier in a subspace, it cannot become an outlier in an overlapping subspace
+#' but it still has the same probability to become an outlier in another space. This appends occasionally (pigeonhole principle)
 #'
-#' If the point if not an outlier, it will have \code{0} as label, otherwise, it has a string representing the different subspaces
+#' If the point is not an outlier, it will have \code{0} as label, otherwise it has a string representing the different subspaces.
 #'
 #' @author Edouard Fouché, \email{edouard.fouche@kit.edu}
 #'
@@ -42,11 +42,52 @@ generate.row <- function(dim=10, subspaces=list(c(3,4), c(7,8)), margins=list(0.
     # https://en.wikipedia.org/wiki/Vector_projection
     a1 <- sum(p*(b/sqrt(length(b))))
     va1 <- a1 * (b/sqrt(length(b)))
-    vd <- p-va1
+    vd <- p - va1 
     d <- sqrt(sum(vd**2))
-    d > 0.5 - margins[subspace]/2
+    d > 0.5 - margins[[subspace]]/2
   }
-  
+  isInHiddenSpace.Cross <- function(row, subspace, marginFactor = 1) {
+      getVectorProjectionOnDiagonal <- function(start, end, point) {
+        diagonal <- end - start
+        result <- list(va1=numeric(0), va2=numeric(0))
+        result$va1 <- sum((point-start) * (diagonal/sqrt(length(diagonal)))) * (diagonal/sqrt(length(diagonal)))
+        result$va2 <- (point-start) - result$va1
+        result
+      } 
+      getEuklidLen <- function(vec) {
+        sqrt(sum(vec**2))
+      }
+      createOppositePoint <- function(start) {
+        # Opposite points basically means mirrored aorund (0.5, 0.5)
+        (start - 0.5) * (-1) + 0.5
+      }
+      createDiagList <- function(n=2) {
+        result <- c(starts=vector("list", (n+1)), ends=vector("list", (n+1)))
+        result$starts[[1]] <- rep(0, n)
+        result$ends[[1]] <- rep(1, n)
+        for (i in 2:(n+1)) {
+          result$starts[[i]] <- rep(0, n)
+          result$starts[[i]][[i-1]] <- 1
+          result$ends[[i]] <- createOppositePoint(result$starts[[i]])
+        }
+        result
+      }
+      point <- row[subspaces[[subspace]]]
+      if (marginFactor != 1) {point <- row}
+      n <- length(subspaces[[subspace]])
+      diagonals.list <- createDiagList(n)
+      # T.B.D.
+      diagonals.projections <- vector("list", (n+1))
+      diffs <- vector("list", (n+1))
+      for (i in 1:(n+1)) {
+        diagonals.projections[[i]] <- getVectorProjectionOnDiagonal(diagonals.list$starts[[i]],
+                                                                  diagonals.list$ends[[i]],
+                                                                  point);
+        diffs[i] <- getEuklidLen(diagonals.projections[[i]]$va2)
+      }
+      all(diffs > 0.5 - (margins[[subspace]]*marginFactor)/2)
+  }
+
   ensureOutlyingBehavior.Wall <- function(row, subspace) row[subspaces[[subspace]]] + (1-row[subspaces[[subspace]]])*0.2
   ensureOutlyingBehavior.Square <- function(row, subspace) {
     transformed_r <- row[subspaces[[subspace]]]-0.5
@@ -64,10 +105,9 @@ generate.row <- function(dim=10, subspaces=list(c(3,4), c(7,8)), margins=list(0.
     }
     res
   }
-  
   ensureOutlyingBehavior.Linear <- function(row, subspace){
     d <- 0 # Note: This way is a bit suboptimal but it avoids points at the really border at least. 
-    while(!(d > 0.5 - (margins[subspace]*0.8)/2)) {
+    while(!(d > 0.5 - (margins[[subspace]]*0.8)/2)) {
       p <- runif(length(row[subspaces[[subspace]]]))
       b <- rep(1, length(p))
       # https://en.wikipedia.org/wiki/Vector_projection
@@ -75,6 +115,14 @@ generate.row <- function(dim=10, subspaces=list(c(3,4), c(7,8)), margins=list(0.
       va1 <- a1 * (b/sqrt(length(b)))
       vd <- p-va1
       d <- sqrt(sum(vd**2))
+    }
+    p
+  }
+  ensureOutlyingBehavior.Cross <- function(row, subspace){
+    d <- FALSE 
+    while(!d) {
+      p <- runif(length(row[subspaces[[subspace]]]))
+      d <- isInHiddenSpace(p, subspace, marginFactor = 0.8)
     }
     p
   }
@@ -96,22 +144,25 @@ generate.row <- function(dim=10, subspaces=list(c(3,4), c(7,8)), margins=list(0.
     } else if (dependency == "Linear") {
       isInHiddenSpace <- isInHiddenSpace.Linear
       ensureOutlyingBehavior <- ensureOutlyingBehavior.Linear 
+    } else if (dependency == "Cross") {
+      isInHiddenSpace <- isInHiddenSpace.Cross
+      ensureOutlyingBehavior <- ensureOutlyingBehavior.Cross 
     } else {
       stop("Currently unsupported dependency type")
     }
     
-    # Do something only if the point is already in the hidden space OR the proportion of outlier is absolute. 
+    # Do something only if the point is already in the hidden space OR the proportion of outliers is absolute. 
     if(isInHiddenSpace(r, s) || (proptype=="absolute")) { 
       # Do something only if the point is not already an outlier in any other subspace that has non-empty intersection 
       # If this is the case, we might destroy his outlying behavior in the other subspace, which we want to avoid. 
       if(!any(lapply(subspaces[outlierFlags], function(y) length(intersect(subspaces[[s]],y))) > 0)) {
         outlierFlags[s] <- sample(c(TRUE,FALSE),1,prob=c(prop,1-prop)) # Choose if it is an outlier in this subspace, with probability prob
-        if(!outlierFlags[s]) { # If we decide not to make an outlier out of it, regenerate it outside from the hidden region 
+        if(!outlierFlags[s]) { # If we decide not to make an outlier out of it, regenerate it outside of the hidden region 
           while(isInHiddenSpace(r, s)) {
             r[subspaces[[s]]] <- runif(length(subspaces[[s]])) 
           }
         } else {
-          # Just to make sure we don't go in an infinite loop in the case the margin is too small. 
+          # Just to make sure we don't go in an infinite loop in case the margin is too small. 
           if(margins[[s]] >= 0.1) { 
             while(!isInHiddenSpace(r, s)) {
               r[subspaces[[s]]] <- runif(length(subspaces[[s]])) 
@@ -158,6 +209,8 @@ generate.row <- function(dim=10, subspaces=list(c(3,4), c(7,8)), margins=list(0.
         outlierFlags[x] <- (sqrt(sum((r[subspaces[[x]]]-0.5)**2)) < margins[[x]]/2 - sqrt(((1/(discretize-1))**2)*2)/2) | (sqrt(sum((r[subspaces[[x]]]-0.5)**2)) > 0.5+sqrt(((1/(discretize-1))**2)*2)/2)
       } else if (dependency == "Linear"){
         outlierFlags[x] <- isInHiddenSpace.Linear(r,x)
+      } else if (dependency == "Cross"){
+        outlierFlags[x] <- isInHiddenSpace.Cross(r,x)
       } else {
         stop("Currently unsupported dependency type")
       }
@@ -176,6 +229,8 @@ generate.row <- function(dim=10, subspaces=list(c(3,4), c(7,8)), margins=list(0.
         outlierFlags[x] <- sqrt(sum((r[subspaces[[x]]]-0.5)**2)) < margins[[x]]/2 | sqrt(sum((r[subspaces[[x]]]-0.5)**2)) > 0.5
       } else if (dependency == "Linear") {
         outlierFlags[x] <- isInHiddenSpace.Linear(r,x)
+      } else if (dependency == "Cross") {
+        outlierFlags[x] <- isInHiddenSpace.Cross(r,x)
       } else {
         stop("Currently unsupported dependency type")
       }
@@ -199,10 +254,10 @@ generate.row <- function(dim=10, subspaces=list(c(3,4), c(7,8)), margins=list(0.
 
 
 
-#'  Helper function that generate multiple rows
+#'  Helper function that generates multiple rows.
 #' 
-#' Helper function that generate multiple rows with the same characteristics
-#' Useful to generate a static stream
+#' Helper function that generates multiple rows with the same characteristics.
+#' Useful to generate a static stream.
 #'
 #' @param n Number of rows to generate.
 #' @param dim Number of dimension of the vector generate.


### PR DESCRIPTION
Adding the cross dependency by creating linear dependencies along the diagonals between opposing corners in a (hyper-)cube.

The indexing of the linear dependency threw an error but is fixed now. 

Some minor spelling changes.